### PR TITLE
Selection list only on one line.

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -232,6 +232,7 @@ background: linear-gradient(to right, rgba(242,67,67,1) 0%, rgba(242,67,67,0.8) 
 	right: 10px;
 	top: 0;
 	display: none;
+    white-space: nowrap;
 }
 
 .popup-menu .selection > .active


### PR DESCRIPTION
With the NativeUI, selection lists don't go on 2 lines,
So I though it was better to follow the original behavior.
Thank you,
rt-2